### PR TITLE
Buttons: set HOME wake key defaults as disabled [2/2]

### DIFF
--- a/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
+++ b/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
@@ -1642,7 +1642,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                     Settings.Secure.RING_HOME_BUTTON_BEHAVIOR_DEFAULT,
                     UserHandle.USER_CURRENT);
             mHomeWakeScreen = (Settings.System.getIntForUser(resolver,
-                    Settings.System.HOME_WAKE_SCREEN, 1, UserHandle.USER_CURRENT) == 1);
+                    Settings.System.HOME_WAKE_SCREEN, 0, UserHandle.USER_CURRENT) == 1);
             mBackWakeScreen = (Settings.System.getIntForUser(resolver,
                     Settings.System.BACK_WAKE_SCREEN, 0, UserHandle.USER_CURRENT) == 1);
             mMenuWakeScreen = (Settings.System.getIntForUser(resolver,


### PR DESCRIPTION
* This should really be opt-in as needed by the user,
  not forced upon by default. Setting as off by default
  matches the other wake key settings.
* With these settings removed by overlay, defaulting
  as true they conflict with kernel features like s2w
  on capacitive Key devices.

Change-Id: I28d272e434f052554dc99ff2c18dbca09ea8e1bb