### PR TITLE
appops: Disassociate appops requests from notification broadcasts

### DIFF
--- a/services/core/java/com/android/server/AppOpsService.java
+++ b/services/core/java/com/android/server/AppOpsService.java
@@ -114,6 +114,14 @@ public class AppOpsService extends IAppOpsService.Stub {
         }
     };
 
+    private Runnable mSuSessionChangedRunner = new Runnable() {
+        @Override
+        public void run() {
+            mContext.sendBroadcastAsUser(new Intent(AppOpsManager.ACTION_SU_SESSION_CHANGED),
+                    UserHandle.ALL);
+        }
+    };
+
     final SparseArray<HashMap<String, Ops>> mUidOps
             = new SparseArray<HashMap<String, Ops>>();
 
@@ -1606,7 +1614,7 @@ public class AppOpsService extends IAppOpsService.Stub {
     private void broadcastOpIfNeeded(int op) {
         switch (op) {
             case AppOpsManager.OP_SU:
-                mContext.sendBroadcast(new Intent(AppOpsManager.ACTION_SU_SESSION_CHANGED));
+                mHandler.post(mSuSessionChangedRunner);
                 break;
             default:
                 break;


### PR DESCRIPTION
The AppOpsService is essentially a manager for a set of counters
and permissions. Each operation request has the potential to change
the state and, as such, access to such state is synchronized.

We are whitnessing deadlocks caused by the broadcast and, in fact,
while we want to notify superuser changes eventually, it does not
have to be synchronous with the app ops request. This patch uses the
request to schedule the notification on a handler, leaving the locking
semantics of appops intact.

Change-Id: I94f6dd2c66b9492f95d3c9ffb438b3e6417007d7